### PR TITLE
Виправлено: був виправлен баг з пустим полем ім’я

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,17 +180,24 @@
     }
 
     function closeModal() {
-        document.getElementById('myModal').style.display = "none";
+    document.getElementById('myModal').style.display = "none";
     }
 
     document.getElementById('nameForm').addEventListener('submit', function(event) {
-        event.preventDefault();
-        var name = document.getElementById('name').value;
-        closeModal();
-        var greetingElement = document.getElementById('greeting');
-        greetingElement.innerText = "Привіт, " + name + "!";
-        greetingElement.style.display = "block";
-    });
+    event.preventDefault();
+    var name = document.getElementById('name').value.trim();  // Видаляємо зайві пробіли
+
+    // Перевірка на порожнє ім'я
+    if (name === "") {
+        alert("Будь ласка, введіть ваше ім'я.");  // Виводимо попередження, якщо ім'я порожнє
+        return; 
+    }
+
+    closeModal();
+    var greetingElement = document.getElementById('greeting');
+    greetingElement.innerText = "Привіт, " + name + "!";
+    greetingElement.style.display = "block";
+});
 </script>
 
 </body>


### PR DESCRIPTION
Баг-репорт
Опис проблеми:
При поданні форми модального вікна користувач може залишити поле для імені порожнім, що призводить до некоректного привітання ("Привіт, !").

Кроки для відтворення багу:
1.Відкрити модальне вікно, де користувач має ввести своє ім'я.
2.Залишити поле для імені порожнім або ввести лише пробіли.
3.Натиснути кнопку "Підтвердити".
4.Спостерігати за привітанням на сторінці.

Очікувана поведінка:
Система має вимагати введення імені та не дозволяти залишати поле порожнім. При порожньому полі повинно відображатися попередження про необхідність введення імені.

Фактична поведінка:
Користувач може залишити поле порожнім, і система відображає привітання без імені ("Привіт, !").

Рішення:
Додано перевірку на порожнє значення в полі для введення імені. Якщо ім'я не введене або складається лише з пробілів, користувач отримує попередження з повідомленням "Будь ласка, введіть ваше ім'я", і форма не буде відправлена, поки не буде введене коректне ім'я.